### PR TITLE
Add 'path' attribute

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -602,6 +602,8 @@ func GetAttr(attr string, node int) (string, error) {
 	switch attr {
 	case "id":
 		return GetPeerID(node)
+	case "path":
+		return IpfsDirN(node)
 	default:
 		return "", errors.New("unrecognized attribute")
 	}


### PR DESCRIPTION
It is useful to safely get the IPFS_PATH of a node using `iptb get path`.