### PR TITLE
util: fix test error with setupOpt

### DIFF
--- a/util/proc_unix.go
+++ b/util/proc_unix.go
@@ -1,4 +1,5 @@
 // +build !windows
+
 package iptbutil
 
 import (
@@ -6,8 +7,6 @@ import (
 	"syscall"
 )
 
-func init() {
-	setupOpt = func(cmd *exec.Cmd) {
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	}
+func setupOpt(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 }

--- a/util/proc_windows.go
+++ b/util/proc_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package iptbutil
+
+import (
+	"os/exec"
+)
+
+func setupOpt(cmd *exec.Cmd) {
+	// Do nothing
+}

--- a/util/util.go
+++ b/util/util.go
@@ -22,8 +22,6 @@ import (
 	ma "github.com/jbenet/go-multiaddr-net/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 )
 
-var setupOpt = func(cmd *exec.Cmd) {}
-
 // GetNumNodes returns the number of testbed nodes configured in the testbed directory
 func GetNumNodes() int {
 	for i := 0; i < 2000; i++ {


### PR DESCRIPTION
When running go tests, for example go-ipfs go tests, there was the following error:

```
test/dependencies/iptb/proc_unix.go:11: undefined: setupOpt
```

(See https://circleci.com/gh/ipfs/go-ipfs/3339)

Let's make it simpler and just add a util/proc_windows.go where
setupOpt() is defined to do nothing.