### PR TITLE
Use gx for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "author": "whyrusleeping",
+  "bugs": {
+    "url": "https://github.com/whyrusleeping/iptb"
+  },
+  "gx": {
+    "dvcsimport": "github.com/whyrusleeping/iptb"
+  },
+  "gxDependencies": [
+    {
+      "author": "whyrusleeping",
+      "hash": "QmYzDkkgAEmrcNzFCiYo6L1dTX4EAG1gZkbtdbd9trL4vd",
+      "name": "go-multiaddr",
+      "version": "0.0.0"
+    },
+    {
+      "author": "jbenet",
+      "hash": "QmUBa4w6CbHJUMeGJPDiMEDWsM93xToK1fTnFXnrC8Hksw",
+      "name": "go-multiaddr-net",
+      "version": "1.0.1"
+    }
+  ],
+  "gxVersion": "0.6.0",
+  "issues_url": "",
+  "language": "go",
+  "license": "",
+  "name": "iptb",
+  "version": "0.0.0"
+}

--- a/util/util.go
+++ b/util/util.go
@@ -18,8 +18,8 @@ import (
 
 	serial "github.com/ipfs/go-ipfs/repo/fsrepo/serialize"
 
-	ma "github.com/jbenet/go-multiaddr"
-	manet "github.com/jbenet/go-multiaddr-net"
+	manet "gx/ipfs/QmUBa4w6CbHJUMeGJPDiMEDWsM93xToK1fTnFXnrC8Hksw/go-multiaddr-net"
+	ma "gx/ipfs/QmYzDkkgAEmrcNzFCiYo6L1dTX4EAG1gZkbtdbd9trL4vd/go-multiaddr"
 )
 
 // GetNumNodes returns the number of testbed nodes configured in the testbed directory


### PR DESCRIPTION
This makes iptb use gx to manage its dependencies.