### PR TITLE
Show get attributes

### DIFF
--- a/main.go
+++ b/main.go
@@ -255,9 +255,19 @@ var connectCmd = cli.Command{
 var getCmd = cli.Command{
 	Name:  "get",
 	Usage: "get an attribute of the given node",
+	Description: `Given an attribute name and a node number, prints the value of the attribute for the given node.
+
+You can get the list of valid attributes by passing no arguments.`,
 	Action: func(c *cli.Context) error {
 		if len(c.Args()) < 2 {
 			fmt.Println("iptb get [attr] [node]")
+			fmt.Println("Valid values of [attr] are:")
+			attr_list := util.GetListOfAttr()
+			for _, a := range attr_list {
+				desc, err := util.GetAttrDescr(a)
+				handleErr("error getting attribute description: ", err)
+				fmt.Printf("\t%s: %s\n", a, desc)
+			}
 			os.Exit(1)
 		}
 		attr := c.Args().First()

--- a/main.go
+++ b/main.go
@@ -259,24 +259,32 @@ var getCmd = cli.Command{
 
 You can get the list of valid attributes by passing no arguments.`,
 	Action: func(c *cli.Context) error {
-		if len(c.Args()) < 2 {
-			fmt.Println("iptb get [attr] [node]")
-			fmt.Println("Valid values of [attr] are:")
+		showUsage := func(w io.Writer) {
+			fmt.Fprintln(w, "iptb get [attr] [node]")
+			fmt.Fprintln(w, "Valid values of [attr] are:")
 			attr_list := util.GetListOfAttr()
 			for _, a := range attr_list {
 				desc, err := util.GetAttrDescr(a)
 				handleErr("error getting attribute description: ", err)
-				fmt.Printf("\t%s: %s\n", a, desc)
+				fmt.Fprintf(w, "\t%s: %s\n", a, desc)
 			}
+		}
+		switch len(c.Args()) {
+		case 0:
+			showUsage(os.Stdout)
+		case 2:
+			attr := c.Args().First()
+			num, err := strconv.Atoi(c.Args()[1])
+			handleErr("error parsing node number: ", err)
+
+			val, err := util.GetAttr(attr, num)
+			handleErr("error getting attribute: ", err)
+			fmt.Println(val)
+		default:
+			fmt.Fprintln(os.Stderr, "'iptb get' accepts exactly 0 or 2 arguments")
+			showUsage(os.Stderr)
 			os.Exit(1)
 		}
-		attr := c.Args().First()
-		num, err := strconv.Atoi(c.Args()[1])
-		handleErr("error parsing node number: ", err)
-
-		val, err := util.GetAttr(attr, num)
-		handleErr("error getting attribute: ", err)
-		fmt.Println(val)
 		return nil
 	},
 }

--- a/util/util.go
+++ b/util/util.go
@@ -646,3 +646,22 @@ func GetAttr(attr string, node int) (string, error) {
 		return "", errors.New("unrecognized attribute")
 	}
 }
+
+func GetListOfAttr() []string {
+	return []string{"id", "path", "bw_in", "bw_out"}
+}
+
+func GetAttrDescr(attr string) (string, error) {
+	switch attr {
+	case "id":
+		return "node ID", nil
+	case "path":
+		return "node IPFS_PATH", nil
+	case "bw_in":
+		return "node input bandwidth", nil
+	case "bw_out":
+		return "node output bandwidth", nil
+	default:
+		return "", errors.New("unrecognized attribute")
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -622,44 +622,49 @@ func GetBW(node int) (*BW, error) {
 	return &bw, nil
 }
 
+const (
+	attrId    = "id"
+	attrPath  = "path"
+	attrBwIn  = "bw_in"
+	attrBwOut = "bw_out"
+)
+
 func GetAttr(attr string, node int) (string, error) {
 	switch attr {
-	case "id":
+	case attrId:
 		return GetPeerID(node)
-	case "path":
+	case attrPath:
 		return IpfsDirN(node)
-	case "bw_in":
+	case attrBwIn:
 		bw, err := GetBW(node)
 		if err != nil {
 			return "", err
 		}
-
 		return fmt.Sprint(bw.TotalIn), nil
-	case "bw_out":
+	case attrBwOut:
 		bw, err := GetBW(node)
 		if err != nil {
 			return "", err
 		}
-
 		return fmt.Sprint(bw.TotalOut), nil
 	default:
-		return "", errors.New("unrecognized attribute")
+		return "", errors.New("unrecognized attribute: " + attr)
 	}
 }
 
 func GetListOfAttr() []string {
-	return []string{"id", "path", "bw_in", "bw_out"}
+	return []string{attrId, attrPath, attrBwIn, attrBwOut}
 }
 
 func GetAttrDescr(attr string) (string, error) {
 	switch attr {
-	case "id":
+	case attrId:
 		return "node ID", nil
-	case "path":
+	case attrPath:
 		return "node IPFS_PATH", nil
-	case "bw_in":
+	case attrBwIn:
 		return "node input bandwidth", nil
-	case "bw_out":
+	case attrBwOut:
 		return "node output bandwidth", nil
 	default:
 		return "", errors.New("unrecognized attribute")


### PR DESCRIPTION
This is to make it possible to see which attributes `iptb get` accepts.

Maybe `iptb get` with no arguments should also exit with code 0 instead of one, but if I replace the `os.Exit(1)` with a `return` I get the following warning when running `iptb get`:

```
DEPRECATED Action signature.  Must be `cli.ActionFunc`.  This is an error in the application.  Please contact the distributor of this application if this is not you.  See https://github.com/codegangsta/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature
```