### PR TITLE
make LocalNode.Kill more persistent and aggressive

### DIFF
--- a/util/example/ipfs_test.go
+++ b/util/example/ipfs_test.go
@@ -29,22 +29,26 @@ func TestWhatIPFSIsUpTo(t *testing.T) {
 
 	// the shutdown process is a slow one for some reason, so lets see if we can
 	// get some goroutine info out of ipfs in the middle of it
+	printIpfsGoroutines(addr)
 	go func() {
 		time.Sleep(3 * time.Second)
-
-		res, err := http.Get("http://" + addr + "/debug/pprof/goroutine?debug=2")
-		if err != nil {
-			log.Println("failed to get ipfs pprof goroutine:", err)
-			return
-		}
-		defer res.Body.Close()
-
-		body, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			log.Println("failed to read pprof body:", err)
-			return
-		}
-
-		log.Printf("pprof goroutine: %s\n", body)
+		printIpfsGoroutines(addr)
 	}()
+}
+
+func printIpfsGoroutines(address string) {
+	res, err := http.Get("http://" + address + "/debug/pprof/goroutine?debug=2")
+	if err != nil {
+		log.Println("failed to get ipfs pprof goroutine:", err)
+		return
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Println("failed to read pprof body:", err)
+		return
+	}
+
+	log.Printf("pprof goroutine: %s\n", body)
 }

--- a/util/example/ipfs_test.go
+++ b/util/example/ipfs_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func TestWhatIPFSIsUpTo(t *testing.T) {
+	addr, err := AddressForNode(0)
+	if err != nil {
+		t.Fatal("failed to get shell for node 0:", err)
+	}
+
+	res, err := http.Get("http://" + addr + "/api/v0/diag/cmds")
+	if err != nil {
+		t.Fatal("failed to get ipfs diag cmds:", err)
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal("failed to read response body:", err)
+	}
+
+	t.Logf("body: %s", body)
+}

--- a/util/example/main.go
+++ b/util/example/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("run go test")
+}

--- a/util/example/main.go
+++ b/util/example/main.go
@@ -3,5 +3,5 @@ package main
 import "fmt"
 
 func main() {
-	fmt.Println("run go test")
+	fmt.Println("run go test -v")
 }

--- a/util/example/main_test.go
+++ b/util/example/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/ipfs/go-ipfs-api"
+	"github.com/whyrusleeping/iptb/util"
+)
+
+func TestMain(m *testing.M) {
+	iptbDir, nodes, err := iptbutil.SetupNodesForTest(2, "example-test-")
+	if err != nil {
+		tdErr := iptbutil.TeardownNodesForTest(iptbDir, nodes)
+		if tdErr != nil {
+			log.Fatalf("failed to setup nodes for test: %s, and then failed to tear them down: %s", err, tdErr)
+		}
+		log.Fatal("failed to setup nodes for test:", err)
+	}
+
+	r := m.Run()
+
+	err = iptbutil.TeardownNodesForTest(iptbDir, nodes)
+	if err != nil {
+		log.Print("failed to tear down nodes for tests:", err)
+	}
+
+	os.Exit(r)
+}
+
+func AddressForNode(n int) (string, error) {
+	node, err := iptbutil.LoadNodeN(n)
+	if err != nil {
+		return "", err
+	}
+
+	return node.APIAddr()
+}
+
+func NewShellForNode(n int) (*shell.Shell, error) {
+	addr, err := AddressForNode(n)
+	if err != nil {
+		return nil, err
+	}
+
+	s := shell.NewShell(addr)
+	if !s.IsUp() {
+		return nil, fmt.Errorf("ipfs node does not seem to be up")
+	}
+
+	return s, nil
+}

--- a/util/localnode.go
+++ b/util/localnode.go
@@ -245,6 +245,11 @@ func (n *LocalNode) Kill() error {
 	var timedOut bool
 	timeout := time.Now().Add(time.Second * 5)
 
+	_, err = p.Wait()
+	if err != nil {
+		return fmt.Errorf("error killing daemon %s: %s\n", n.Dir, err)
+	}
+
 	for {
 		err := p.Signal(syscall.Signal(0))
 		if err != nil {

--- a/util/localnode.go
+++ b/util/localnode.go
@@ -237,7 +237,7 @@ func (n *LocalNode) Kill() error {
 	if err != nil {
 		return fmt.Errorf("error killing daemon %s: %s", n.Dir, err)
 	}
-	err = p.Kill()
+	err = p.Signal(os.Interrupt)
 	if err != nil {
 		return fmt.Errorf("error killing daemon %s: %s\n", n.Dir, err)
 	}
@@ -260,7 +260,7 @@ func (n *LocalNode) Kill() error {
 	}
 
 	if timedOut {
-		err := p.Kill()
+		err := p.Signal(os.Interrupt)
 		if err != nil {
 			return fmt.Errorf("error killing daemon %s: %s\n", n.Dir, err)
 		}
@@ -284,7 +284,7 @@ func (n *LocalNode) Kill() error {
 	}
 
 	if timedOut {
-		err := p.Signal(os.Interrupt)
+		err := p.Signal(os.Kill)
 		if err != nil {
 			return fmt.Errorf("error killing daemon %s: %s\n", n.Dir, err)
 		}

--- a/util/test_helpers.go
+++ b/util/test_helpers.go
@@ -1,0 +1,85 @@
+package iptbutil
+
+import (
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"os"
+	"time"
+)
+
+// SetupNodesForTest is a helper function intended to be used in the context of
+// a TestMain(*testing.M) function. It sets up some iptb based nodes and
+// returns the name of the temporary iptb directory it created, the slice of
+// nodes, and an error. Even when the error is not nil, the the directory or
+// the nodes may contain useful information. The string and slice returned are
+// always safe to pass to the TeardownNodesForTest function.
+func SetupNodesForTest(count int, prefix string) (string, []IpfsNode, error) {
+	iptbDir, err := ioutil.TempDir("", prefix)
+	if err != nil {
+		return "", nil, err
+	}
+
+	err = os.Setenv("IPTB_ROOT", iptbDir)
+	if err != nil {
+		return iptbDir, nil, err
+	}
+
+	// Need to randomize ports in case a previous run is taking its sweet time to
+	// shut down, or something.
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	ps := 15000 + (rnd.Int()%500)*10
+
+	cfg := &InitCfg{
+		Count:     count,
+		Force:     true,
+		Bootstrap: "star",
+		PortStart: ps,
+		Mdns:      false,
+		Utp:       false,
+		Override:  "",
+		NodeType:  "",
+	}
+	err = IpfsInit(cfg)
+	if err != nil {
+		return iptbDir, nil, err
+	}
+
+	nodes, err := LoadNodes()
+	if err != nil {
+		return iptbDir, nil, err
+	}
+
+	err = IpfsStart(nodes, true, []string{})
+	if err != nil {
+		for i, n := range nodes {
+			killerr := n.Kill()
+			if killerr != nil {
+				log.Println("failed to kill node", i, ":", killerr)
+			} else {
+				log.Println("killed node", i)
+			}
+		}
+		return iptbDir, nodes, err
+	}
+
+	return iptbDir, nodes, nil
+}
+
+// TeardownNodesForTest cleans up the iptb cluster that was set up by
+// SetupNodesForTest. Always safe to call with the things returned by
+// SetupNodesForTest.
+func TeardownNodesForTest(iptbDir string, nodes []IpfsNode) error {
+	if nodes != nil {
+		err := IpfsKillAll(nodes)
+		if err != nil {
+			return err
+		}
+	}
+
+	if iptbDir != "" {
+		return os.RemoveAll(iptbDir)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds some retry logic to the LocalNode.Kill method to make try killing multiple times. Waits for 5 seconds after the first kill, and if the process is still running, sends a second kill and waits for another 10 seconds. If the process is *still* running after that, sends an Interrupt and moves on.