### PR TITLE
Fixing typo in command error output, and docker image name.

### DIFF
--- a/main.go
+++ b/main.go
@@ -422,7 +422,7 @@ var setCmd = cli.Command{
 				}
 			}
 		default:
-			fmt.Fprintln(os.Stderr, "'iptb set' accepts exactly 2 arguments")
+			fmt.Fprintln(os.Stderr, "'iptb set' accepts exactly 3 arguments")
 			os.Exit(1)
 		}
 		return nil

--- a/util/util.go
+++ b/util/util.go
@@ -261,7 +261,7 @@ func initSpecs(cfg *InitCfg) ([]*NodeSpec, error) {
 
 		switch cfg.NodeType {
 		case "docker":
-			img := "go-ipfs"
+			img := "ipfs/go-ipfs"
 			if altimg := os.Getenv("IPFS_DOCKER_IMAGE"); altimg != "" {
 				img = altimg
 			}


### PR DESCRIPTION
Two fixes:

1. One minor typo in error output for shell command
2. Docker image name (needs username `ipfs` in order to pull from dockerhub)